### PR TITLE
update examples to use .well-known/agent-skills/ path

### DIFF
--- a/examples/skills-index.astro.ts
+++ b/examples/skills-index.astro.ts
@@ -1,12 +1,12 @@
 /**
- * Astro API route that generates /.well-known/skills/index.json.
+ * Astro API route that generates /.well-known/agent-skills/index.json.
  * Runs at build time (static) or request time (SSR) depending on your Astro config.
  *
- * Scans public/.well-known/skills/ for skill directories, parses YAML frontmatter
+ * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
  * from each SKILL.md, collects all files, and outputs a JSON index per the Agent Skills Discovery spec.
  *
- * Usage: Place this file at src/pages/.well-known/skills/index.json.ts
- * Skills: Place skill directories at public/.well-known/skills/{name}/SKILL.md
+ * Usage: Place this file at src/pages/.well-known/agent-skills/index.json.ts
+ * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
  *
  * Requires: gray-matter (npm install gray-matter)
  */
@@ -38,7 +38,7 @@ async function collectFiles(dir: string, baseDir: string): Promise<string[]> {
 }
 
 export async function GET() {
-	const skillsDir = join(process.cwd(), "public/.well-known/skills");
+	const skillsDir = join(process.cwd(), "public/.well-known/agent-skills");
 
 	let entries;
 	try {

--- a/examples/skills-index.cgi
+++ b/examples/skills-index.cgi
@@ -1,13 +1,13 @@
 #!/usr/bin/perl
 #
-# CGI script that generates /.well-known/skills/index.json
+# CGI script that generates /.well-known/agent-skills/index.json
 # A throwback to simpler times. Works with Apache, Nginx (via fcgiwrap), or any CGI-capable server.
 #
 # Scans the skills directory for subdirectories, parses YAML frontmatter
 # from each SKILL.md, and outputs a JSON index per the Agent Skills Discovery spec.
 #
-# Usage: Place in cgi-bin/ and configure your server to serve it at /.well-known/skills/index.json
-# Skills: Place skill directories at /var/www/html/.well-known/skills/{name}/SKILL.md
+# Usage: Place in cgi-bin/ and configure your server to serve it at /.well-known/agent-skills/index.json
+# Skills: Place skill directories at /var/www/html/.well-known/agent-skills/{name}/SKILL.md
 #
 # Note: Only single-line name/description values are supported (no YAML multi-line syntax)
 #
@@ -18,7 +18,7 @@ use warnings;
 use JSON::PP;
 
 # Configure this path to match your setup
-my $skills_dir = $ENV{SKILLS_DIR} || '/var/www/html/.well-known/skills';
+my $skills_dir = $ENV{SKILLS_DIR} || '/var/www/html/.well-known/agent-skills';
 
 print "Content-Type: application/json\r\n";
 print "Cache-Control: public, max-age=300\r\n\r\n";

--- a/examples/skills-index.nextjs.ts
+++ b/examples/skills-index.nextjs.ts
@@ -1,12 +1,12 @@
 /**
- * Next.js Route Handler that generates /.well-known/skills/index.json.
+ * Next.js Route Handler that generates /.well-known/agent-skills/index.json.
  * Runs at build time when using static export, or at request time (cached via route config).
  *
- * Scans public/.well-known/skills/ for skill directories, parses YAML frontmatter
+ * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
  * from each SKILL.md, collects all files, and outputs a JSON index per the Agent Skills Discovery spec.
  *
- * Usage: Place this file at app/.well-known/skills/index.json/route.ts
- * Skills: Place skill directories at public/.well-known/skills/{name}/SKILL.md
+ * Usage: Place this file at app/.well-known/agent-skills/index.json/route.ts
+ * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
  *
  * Requires: gray-matter (npm install gray-matter)
  */
@@ -41,7 +41,7 @@ async function collectFiles(dir: string, baseDir: string): Promise<string[]> {
 export const dynamic = "force-static";
 
 export async function GET() {
-	const skillsDir = join(process.cwd(), "public/.well-known/skills");
+	const skillsDir = join(process.cwd(), "public/.well-known/agent-skills");
 
 	let entries;
 	try {

--- a/examples/skills-index.tanstack.ts
+++ b/examples/skills-index.tanstack.ts
@@ -1,12 +1,12 @@
 /**
- * TanStack Start API route that generates /.well-known/skills/index.json.
+ * TanStack Start API route that generates /.well-known/agent-skills/index.json.
  * Runs at request time.
  *
- * Scans public/.well-known/skills/ for skill directories, parses YAML frontmatter
+ * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
  * from each SKILL.md, collects all files, and outputs a JSON index per the Agent Skills Discovery spec.
  *
- * Usage: Place this file at app/routes/.well-known/skills/index.json.ts
- * Skills: Place skill directories at public/.well-known/skills/{name}/SKILL.md
+ * Usage: Place this file at app/routes/.well-known/agent-skills/index.json.ts
+ * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
  *
  * Requires: gray-matter (npm install gray-matter)
  */
@@ -38,9 +38,9 @@ async function collectFiles(dir: string, baseDir: string): Promise<string[]> {
 	return files;
 }
 
-export const APIRoute = createAPIFileRoute("/.well-known/skills/index.json")({
+export const APIRoute = createAPIFileRoute("/.well-known/agent-skills/index.json")({
 	GET: async () => {
-		const skillsDir = join(process.cwd(), "public/.well-known/skills");
+		const skillsDir = join(process.cwd(), "public/.well-known/agent-skills");
 
 		let entries;
 		try {


### PR DESCRIPTION
Fixes stale path references in the example index files — all four previously pointed to `.well-known/skills/` instead of `.well-known/agent-skills/`.

- Updated comments, usage instructions, skills placement notes, and runtime path literals in all four examples (CGI, Astro, Next.js, TanStack)
- The TanStack file also had the stale path in the `createAPIFileRoute()` argument, which is now corrected