### PR TITLE
Re-apply PR #8 changes that were missed during the `v0.2.0` merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Agent Skills Discovery via Well-Known URIs
 
-**Status**: Draft  
-**Version**: 0.2.0  
-**Published Date**: 2026-01-17  
-**Updated Date**: 2026-02-13
+**Status**: Draft
+**Version**: 0.2.0
+**Published Date**: 2026-01-17
+**Updated Date**: 2026-03-12
 
 ## Table of Contents
 
@@ -14,10 +14,10 @@
 5. [Solution](#solution)
 6. [URI Structure](#uri-structure)
 7. [Skill Directory Contents](#skill-directory-contents)
-8. [Progressive Disclosure](#progressive-discovery)
+8. [Progressive Disclosure](#progressive-disclosure)
 9. [Discovery Index](#discovery-index)
 10. [Integrity and Verification](#integrity-and-verification)
-11. [Package Distribution](#package-distribution)
+11. [Archive Distribution](#archive-distribution)
 12. [Examples](#examples)
 13. [HTTP Considerations](#http-considerations)
 14. [Client Implementation](#client-implementation)
@@ -27,20 +27,22 @@
 
 ## Abstract
 
-This document defines a mechanism for discovering [Agent Skills](https://agentskills.io/) using the `.well-known` URI path prefix as specified in [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615). Skills are currently scattered across GitHub repositories, documentation sites, in other sources. A well-known URI provides a predictable location for agents and tools to discover skills published by an organization or project.
+This document defines a mechanism for discovering [Agent Skills](https://agentskills.io/) using the `.well-known` URI path prefix as specified in [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615). Skills are currently scattered across GitHub repositories, documentation sites, and other sources. A well-known URI provides a predictable location for agents and tools to discover skills published by an organization or project.
 
 ## Changelog
 
 #### v0.2.0
 
-- add `version` field to `index.json`; define strict `M.m.p` versioning scheme
-- add per-skill and per-file content digests (`digest` field) for integrity verification
-- `files` array entries are now objects with `path` and `digest` (breaking change from v0.1.0 string arrays)
-- add optional `package` property for archive-based distribution
+- rename well-known URI from `/.well-known/skills/` to `/.well-known/agent-skills/`
+- replace `version` field with `$schema` URI (`https://schemas.agentskills.io/discovery/0.2.0/schema.json`)
+- replace `files` array and `package` object with a flat single-artifact model: each skill entry now has `type` (`"skill-md"` or `"archive"`), `url`, and `digest`
+- `digest` is now the SHA-256 of the single artifact (not a manifest-derived skill-level digest)
+- add archive safety guidance: path traversal, symlinks, decompression bombs
+- add URL resolution semantics per RFC 3986
 - add RFC 2119 / RFC 8174 keyword conventions
 - strengthen script execution guidance — clients SHALL NOT execute scripts by default
-- add "Integrity and Verification" section defining digest construction and verification
-- add "Package Distribution" section
+- add "Integrity and Verification" section
+- add "Archive Distribution" section
 - add backward-compatibility guidance for v0.1.0 clients
 
 #### v0.1.0
@@ -64,7 +66,7 @@ There is no standard way to answer: "What skills does example.com publish?"
 
 ## Solution
 
-Register `skills` as a well-known URI suffix. Organizations can publish skills at:
+Register `agent-skills` as a well-known URI suffix. Organizations can publish skills at:
 
 ```
 https://example.com/.well-known/agent-skills/
@@ -74,27 +76,27 @@ This provides a **single, predictable location** where agents and tooling can di
 
 ## URI Structure
 
-The well-known skills path uses this hierarchy:
+Publishers MUST provide an index at:
 
 ```
-/.well-known/agent-skills/index.json          # Required: skills index
-/.well-known/agent-skills/{skill-name}/       # Skill directory
-/.well-known/agent-skills/{skill-name}/SKILL.md
+/.well-known/agent-skills/index.json
 ```
 
-The `{skill-name}` segment must conform to the [Agent Skills specification](https://agentskills.io/specification):
+Each skill in the index includes a `url` field pointing to its artifact. While publishers conventionally host skill files under `/.well-known/agent-skills/`, the `url` field allows skills to be hosted at any location (e.g., on a CDN or at a versioned path).
+
+Skill names MUST conform to the [Agent Skills specification](https://agentskills.io/specification):
 
 - 1-64 characters
 - Lowercase alphanumeric and hyphens only (`a-z`, `0-9`, `-`)
-- Must not start or end with a hyphen
-- Must not contain consecutive hyphens
+- MUST NOT start or end with a hyphen
+- MUST NOT contain consecutive hyphens
 
 ## Skill Directory Contents
 
-Each skill directory must contain a `SKILL.md` file and may include supporting resources:
+A skill consists of a required `SKILL.md` file and optional supporting resources:
 
 ```
-/.well-known/agent-skills/pdf-processing/
+skill-name/
 ├── SKILL.md           # Required: instructions + metadata
 ├── scripts/           # Optional: executable code
 │   └── extract.py
@@ -104,11 +106,13 @@ Each skill directory must contain a `SKILL.md` file and may include supporting r
     └── schema.json
 ```
 
-The `SKILL.md` file must contain YAML frontmatter with `name` and `description` fields, followed by Markdown instructions.
+Skills consisting of `SKILL.md` alone are typically distributed as individual files (`type: "skill-md"` in the index). Skills with supporting resources are distributed as archives (`type: "archive"` in the index). See [Discovery Index](#discovery-index) for details.
+
+The `SKILL.md` file MUST contain YAML frontmatter with `name` and `description` fields, followed by Markdown instructions.
 
 ## Progressive Disclosure
 
-Skills use a three-level loading pattern to manage context efficiently:
+Skills use a progressive loading pattern to manage context efficiently:
 
 | Level | What | When Loaded | Token Cost |
 |-------|------|-------------|------------|
@@ -116,13 +120,13 @@ Skills use a three-level loading pattern to manage context efficiently:
 | 2 | Full `SKILL.md` body | When skill is activated | < 5k tokens recommended |
 | 3 | Referenced files (scripts, references, assets) | On demand, as needed | Unlimited |
 
-**Level 1: Index metadata.** Agents fetch `index.json` to learn what skills exist and prefetch their files. Only the name and description are loaded into context initially.
+**Level 1: Index metadata.** Agents fetch `index.json` to learn what skills exist. Only the name and description are loaded into context initially.
 
-**Level 2: Skill instructions.** When a task matches a skill's description, the agent fetches `SKILL.md` and loads its full instructions into context.
+**Level 2: Skill instructions.** When a task matches a skill's description, the agent fetches the skill artifact. For `type: "skill-md"` skills, this is `SKILL.md` directly. For `type: "archive"` skills, the agent downloads the archive and extracts `SKILL.md`. The full instructions are loaded into context.
 
-**Level 3: Supporting resources.** The `SKILL.md` body references additional files via relative links. Agents fetch these on demand as the task requires - a form-filling task might need `references/FORMS.md`, while a simple extraction task does not.
+**Level 3: Supporting resources.** For archive-based skills, the `SKILL.md` body references additional files via relative links. Agents load these from the unpacked archive on demand as the task requires — a form-filling task might need `references/FORMS.md`, while a simple extraction task does not.
 
-This pattern means a skill can bundle extensive reference material without paying a context cost upfront. Agents follow links as needed, fetching only what the current task requires.
+This pattern means a skill can bundle extensive reference material without paying a context cost upfront. Agents follow links as needed, loading only what the current task requires.
 
 ### Example: Progressive loading
 
@@ -158,217 +162,137 @@ An agent handling "extract text from this PDF" loads `SKILL.md` and stops there.
 
 ## Discovery Index
 
-Publishers MUST provide an index at `/.well-known/agent-skills/index.json`. The index enumerates all available skills and their files, enabling clients to discover and prefetch skill resources in a single request.
+Publishers MUST provide an index at `/.well-known/agent-skills/index.json`. The index enumerates all available skills, enabling clients to discover skills in a single request.
 
 ### Versioning
 
-The index MUST include a top-level `version` field conforming to `M.m.p` format (major.minor.patch), where M, m, and p are non-negative integers with no leading zeros.
+The index MUST include a top-level `$schema` field containing a URI that identifies the index schema version. The current schema URI is:
 
-- **Major** (`M`): Incremented for backward-incompatible changes to the index schema. Clients encountering an unrecognized major version SHOULD reject the index and warn the user.
-- **Minor** (`m`): Incremented for backward-compatible additions (new optional fields, new sections). Clients MUST ignore unrecognized fields.
-- **Patch** (`p`): Incremented for clarifications or editorial changes that do not affect the schema.
-- Pre-1.0 versions (major = 0) MAY include breaking changes in minor releases.
+```
+https://schemas.agentskills.io/discovery/0.2.0/schema.json
+```
 
-Clients MUST parse the `version` field before processing the index. If `version` is absent, clients SHOULD treat the index as v0.1.0 for backward compatibility.
+The `$schema` URI is an **opaque identifier**. Clients MUST match it against known schema URIs to determine how to process the index. The URI does not need to be resolvable, though it MAY point to a [JSON Schema](https://json-schema.org/) document that describes the index format.
+
+Clients encountering an unrecognized `$schema` URI SHOULD warn the user and SHOULD NOT process the index. If `$schema` is absent, clients SHOULD treat the index as v0.1.0 for backward compatibility. Clients MUST ignore unrecognized fields.
 
 ### Index Format
 
 ```json
 {
-  "version": "0.2.0",
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "skills": [
     {
-      "name": "wrangler",
-      "description": "Deploy and manage Cloudflare Workers projects.",
-      "digest": "sha256:a1b2c3d4...",
-      "files": [
-        { "path": "SKILL.md", "digest": "sha256:d4e5f6a7..." },
-        { "path": "references/commands.md", "digest": "sha256:7a8b9c0d..." },
-        { "path": "references/configuration.md", "digest": "sha256:0d1e2f3a..." }
-      ],
-      "package": {
-        "url": "https://example.com/.well-known/agent-skills/wrangler.tar.gz",
-        "digest": "sha256:f1e2d3c4..."
-      }
+      "name": "code-review",
+      "type": "skill-md",
+      "description": "Review code for bugs, security issues, and best practices.",
+      "url": "/.well-known/agent-skills/code-review/SKILL.md",
+      "digest": "sha256:c4d5e6f7..."
     },
     {
-      "name": "code-review",
-      "description": "Review code for bugs, security issues, and best practices.",
-      "digest": "sha256:c4d5e6f7...",
-      "files": [
-        { "path": "SKILL.md", "digest": "sha256:a7b8c9d0..." }
-      ]
+      "name": "wrangler",
+      "type": "archive",
+      "description": "Deploy and manage Cloudflare Workers projects.",
+      "url": "/.well-known/agent-skills/wrangler.tar.gz",
+      "digest": "sha256:a1b2c3d4..."
     }
   ]
 }
 ```
 
-The index contains a top-level `version` field and a `skills` array.
+The index contains a top-level `$schema` field and a `skills` array.
 
 **Top-level fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `version` | Yes | Index schema version in `M.m.p` format. Current version is `0.2.0`. |
+| `$schema` | Yes | URI identifying the index schema version. See [Versioning](#versioning). |
 | `skills` | Yes | Array of skill entries. |
 
 **Skill entry fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Skill identifier. MUST match the directory name under `/.well-known/agent-skills/` and conform to the [Agent Skills naming specification](https://agentskills.io/specification#name-field): 1-64 characters, lowercase alphanumeric and hyphens only, no leading/trailing/consecutive hyphens. |
-| `description` | Yes | Brief description of what the skill does and when to use it. Max 1024 characters per the Agent Skills spec. |
-| `digest` | Yes | SHA-256 content digest of the skill. Used for change detection and validation. See [Integrity and Verification](#integrity-and-verification). |
-| `files` | Yes | Array of file objects in the skill directory. See [Files Array](#files-array). |
-| `package` | No | Archive distribution object with `url` and `digest`. See [Package Distribution](#package-distribution). |
+| `name` | Yes | Skill identifier. MUST conform to the [Agent Skills naming specification](https://agentskills.io/specification#name-field): 1-64 characters, lowercase alphanumeric and hyphens only, no leading/trailing/consecutive hyphens. |
+| `type` | Yes | Distribution type. MUST be `"skill-md"` (single `SKILL.md` file) or `"archive"` (bundled archive). |
+| `description` | Yes | Brief description of what the skill does and when to use it. Max 1024 characters per the Agent Skills spec. SHOULD match the `description` field in the skill's `SKILL.md` frontmatter. |
+| `url` | Yes | URL to the skill artifact. For `type: "skill-md"`, this points to the `SKILL.md` file. For `type: "archive"`, this points to the archive file. See [URL Resolution](#url-resolution). |
+| `digest` | Yes | SHA-256 content digest of the artifact at `url`, formatted as `sha256:{hex}` where `{hex}` is 64 lowercase hexadecimal characters. See [Integrity and Verification](#integrity-and-verification). |
 
-Clients derive the skill path from the `name` field directly:
+> [!NOTE]
+> In a future version, `url` may become optional for `type: "skill-md"` entries, defaulting to `/.well-known/agent-skills/{name}/SKILL.md`.
 
-```
-/.well-known/agent-skills/{name}/SKILL.md
-```
+### URL Resolution
 
-For example, `"name": "wrangler"` maps to `/.well-known/agent-skills/wrangler/SKILL.md`.
+The `url` field specifies where to fetch the skill artifact. URLs are resolved per [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5) using the index URL as the base URI. URLs may be:
 
-### Files Array
+- **Path-absolute** (resolved against the index origin): `/.well-known/agent-skills/code-review/SKILL.md`
+- **Absolute** (fully qualified): `https://cdn.example.com/v2/skills/code-review/SKILL.md`
+- **Relative** (resolved against the index URL directory): `code-review/SKILL.md`
 
-The `files` array lists all files in the skill directory as objects. This enables clients to prefetch and locally cache skill resources, and to verify content integrity per file.
+For `type: "skill-md"`, `url` conventionally follows the pattern `/.well-known/agent-skills/{name}/SKILL.md`, though publishers MAY use any URL.
 
-Each file entry has these fields:
+For `type: "archive"`, `url` points to the archive file. Clients SHOULD determine the archive format from the server's `Content-Type` header, falling back to the URL file extension if the header is absent or generic (e.g., `application/octet-stream`). See [Archive Distribution](#archive-distribution).
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `path` | Yes | File path relative to the skill directory. |
-| `digest` | Yes | `sha256:{hex}` digest of the file's raw bytes. See [Integrity and Verification](#integrity-and-verification). |
-
-**Path requirements:**
-
-- The array MUST be non-empty
-- The array MUST include an entry with `path` value `SKILL.md`
-- The `SKILL.md` entry SHOULD be first
-- Paths MUST be relative to the skill directory
-- Paths MUST use forward slash (`/`) as the separator
-- Paths MUST NOT begin with `/` or contain `..` segments
-- Paths MUST contain only printable ASCII characters (0x20-0x7E), excluding `\`, `?`, `#`, `[`, `]`, and control characters
-- Each path MUST correspond to an actual file served at `/.well-known/agent-skills/{name}/{path}`
-
-**Example entries:**
-
-```json
-{ "path": "SKILL.md", "digest": "sha256:d4e5f6a7..." }
-{ "path": "scripts/deploy.sh", "digest": "sha256:0a1b2c3d..." }
-{ "path": "references/API.md", "digest": "sha256:e5f6a7b8..." }
-{ "path": "assets/config.template.yaml", "digest": "sha256:9c0d1e2f..." }
-```
-
-**Caching and progressive disclosure.** Clients MAY prefetch all files listed in the `files` array for local caching. However, clients MUST NOT load all files into context simultaneously. The [progressive disclosure model](https://agentskills.io/specification#progressive-disclosure) still applies: load `SKILL.md` first, then fetch supporting resources on demand as the task requires.
+Clients encountering an unrecognized `type` value SHOULD skip that skill entry and MAY warn the user.
 
 ### Backward Compatibility
 
-The v0.2.0 `files` array format (objects with `path` and `digest`) is not backward-compatible with v0.1.0 (plain string arrays). Clients encountering string entries in `files` SHOULD treat them as v0.1.0 format — interpret each string as a file path with no digest available. Clients SHOULD warn when processing a v0.1.0 index that integrity verification is not possible.
+The v0.2.0 index format is not backward-compatible with v0.1.0. Key differences:
 
-Publishers SHOULD migrate to v0.2.0 to enable integrity verification for clients.
+- v0.1.0 used `files` as an array of path strings with no digests. v0.2.0 removes `files` entirely, adds `type`, `url`, `digest`, and `$schema`.
+
+Clients MUST check the `$schema` field to determine how to process the index. An unrecognized `$schema` URI indicates the index structure may have changed incompatibly; see [Versioning](#versioning).
 
 ## Integrity and Verification
 
 All digests in the index use SHA-256 and are formatted as `sha256:{hex}`, where `{hex}` is 64 lowercase hexadecimal characters.
 
-### Per-File Digest
+The `digest` field on each skill entry is the SHA-256 hash of the raw bytes of the skill's artifact:
 
-The digest of a file is the SHA-256 hash of the file's raw bytes, hex-encoded with the `sha256:` prefix:
+- For `type: "skill-md"`: the SHA-256 of the `SKILL.md` file's raw bytes.
+- For `type: "archive"`: the SHA-256 of the archive file's raw bytes.
 
 ```
 sha256:{SHA-256(raw_bytes)}
 ```
 
-Clients MUST verify downloaded file contents against the per-file digest in the index. A mismatch indicates the content is corrupted or has been tampered with; clients MUST NOT use unverified content.
+### Verification
 
-### Skill-Level Digest
+Clients MUST verify downloaded content against the `digest` in the index. A mismatch indicates the content is corrupted or has been tampered with; clients MUST NOT use unverified content.
 
-The skill-level digest provides a single value for change detection across all files in a skill. It is computed deterministically from the per-file digests:
+- **Change detection**: Compare a skill's `digest` against a locally cached value. If they match, the artifact is unchanged and the client can skip re-downloading.
+- **Download verification**: After downloading a skill artifact, compute its SHA-256 and compare against the `digest`. Reject on mismatch.
 
-1. Collect all entries from the skill's `files` array.
-2. Sort entries lexicographically by `path` (byte-order, ASCII).
-3. For each entry, construct a manifest line: `{path}\0{hex}\n`
-   - `{path}` is the relative file path
-   - `\0` is a null byte (0x00) separator
-   - `{hex}` is the 64-character lowercase hex SHA-256 of the file's raw bytes (without the `sha256:` prefix)
-   - `\n` is a newline (0x0A)
-4. Concatenate all manifest lines in sorted order.
-5. Compute SHA-256 of the resulting bytes.
-6. Format as `sha256:{hex}`.
+## Archive Distribution
 
-#### Worked example
+Skills with supporting files (scripts, references, assets) are distributed as archives with `type: "archive"` in the index. The archive contains the full skill directory, including `SKILL.md` and all supporting resources.
 
-Given a skill with two files:
+### Supported Formats
 
-| File | Contents (bytes) | SHA-256 |
-|------|-------------------|---------|
-| `SKILL.md` | `# Hello\n` (8 bytes) | `90f8ec5669cd34183b9b0fdf8b94f5efb4c3672876330f4aa76088c2b4ad17be` |
-| `scripts/run.sh` | `#!/bin/sh\n` (10 bytes) | `a8076d3d28d21e02012b20eaf7dbf75409a6277134439025f282e368e3305abf` |
+Archives SHOULD be in `.tar.gz` (gzip-compressed tar) or `.zip` format. Clients MUST support at least `.tar.gz` and `.zip`. Each format has different tradeoffs:
 
-**Step 1-2.** Sort by path: `SKILL.md`, then `scripts/run.sh`.
-
-**Step 3-4.** Construct the manifest (shown with escape sequences):
-
-```
-SKILL.md\x0090f8ec5669cd34183b9b0fdf8b94f5efb4c3672876330f4aa76088c2b4ad17be\n
-scripts/run.sh\x00a8076d3d28d21e02012b20eaf7dbf75409a6277134439025f282e368e3305abf\n
-```
-
-**Step 5-6.** SHA-256 of the manifest bytes:
-
-```
-sha256:34f7a8c484e9991f3e71a309f31332d6335efc01f544105c4185a7c4ab12eb1e
-```
-
-Implementers can use these values to validate their digest computation.
-
-### Verification Flows
-
-- **Change detection**: Compare the skill-level `digest` against a locally cached value. If they match, no files have changed and the client can skip updating.
-- **Individual file verification**: After downloading a file, compute its SHA-256 and compare against the per-file `digest` in the index. Reject on mismatch.
-- **Post-fetch validation**: After all files are fetched or unpacked from a package, recompute the skill-level digest from the downloaded file contents and verify it matches the skill-level `digest`. This guards against partial updates or index/content desynchronization.
-
-## Package Distribution
-
-Publishers MAY provide an optional `package` field on a skill entry for archive-based distribution. This is useful for skills with many files where a single download is more efficient than fetching files individually.
-
-### Package Format
-
-```json
-"package": {
-  "url": "https://example.com/.well-known/agent-skills/wrangler.tar.gz",
-  "digest": "sha256:f1e2d3c4..."
-}
-```
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `url` | Yes | URL to a `.tar.gz` or `.zip` archive containing the skill's files. |
-| `digest` | Yes | `sha256:{hex}` digest of the archive bytes. |
+- **`.tar.gz`**: Robust support for UNIX file permissions and symlinks.
+- **`.zip`**: Limited support for UNIX file permissions and symlinks (varies by implementation). Supports partial file retrieval via HTTP range requests (useful for indexing services that need to read `SKILL.md` without downloading the full archive).
 
 ### Archive Structure
 
-- The archive root corresponds to the skill directory.
-- The archive MUST contain files at paths matching the `files` array entries.
+The archive contents represent the skill directory — files are placed at the archive root, not nested inside a wrapper directory.
+
+- The archive MUST contain a `SKILL.md` file at the root.
 - The archive MUST NOT contain path traversal sequences (`..`) or absolute paths.
 
-### Validation
+### Archive Safety
 
-Clients fetching a package MUST validate it in this order:
+After verifying the archive's digest (see [Integrity and Verification](#integrity-and-verification)), clients unpacking an archive MUST:
 
-1. Download the archive and compute its SHA-256.
-2. Compare against `package.digest`. Reject on mismatch.
-3. Unpack the archive.
-4. Verify each unpacked file's digest against the corresponding per-file `digest` in the index.
-5. Recompute the skill-level digest and verify it matches the skill-level `digest`.
+1. Reject archives containing path traversal sequences (`..`) or absolute paths.
+2. Reject archives containing symlinks or hard links that resolve outside the skill directory.
+3. Consider enforcing a reasonable limit on total unpacked size to prevent denial-of-service via decompression bombs.
 
 ### Distribution Guidance
 
-Simple skills — those with only `SKILL.md` or a small number of files — SHOULD prefer individual file distribution. Individual files are easier for clients to inspect and for users to validate compared to an opaque archive.
-
-The `package` field is OPTIONAL. Publishers MAY provide it, and clients MAY prefer fetching individual files even when `package` is available.
+Simple skills — those with only `SKILL.md` — SHOULD use `type: "skill-md"`. Archives are intended for skills with supporting files where a single download is more efficient and preserves directory structure, file permissions, and symlinks.
 
 ## Examples
 
@@ -403,60 +327,65 @@ docs: update API reference
 
 ### Complex skill with resources
 
-A skill with scripts and reference documentation:
+A skill with scripts and reference documentation, distributed as an archive:
 
 ```
-/.well-known/agent-skills/data-pipeline/
+wrangler.tar.gz (archive contents)
 ├── SKILL.md
 ├── scripts/
-│   ├── validate.py
-│   └── transform.py
+│   ├── deploy.sh
+│   └── init.sh
 ├── references/
-│   ├── SCHEMA.md
-│   └── ERROR_CODES.md
+│   ├── COMMANDS.md
+│   └── CONFIGURATION.md
 └── assets/
-    └── config.template.yaml
+    └── wrangler.toml.template
 ```
 
 The `SKILL.md` references these files for progressive disclosure:
 
 ```yaml
 ---
-name: data-pipeline
-description: Build and validate data pipelines. Use when processing datasets or ETL workflows.
+name: wrangler
+description: Deploy and manage Cloudflare Workers projects.
 ---
 
-# Data Pipeline
+# Wrangler
 
-## Validation
+## Deployment
 
-Run `scripts/validate.py` against your dataset before processing.
+Run `scripts/deploy.sh` to deploy your Worker.
 
-For schema requirements, see [references/SCHEMA.md](references/SCHEMA.md).
+For available commands, see [references/COMMANDS.md](references/COMMANDS.md).
+For configuration options, see [references/CONFIGURATION.md](references/CONFIGURATION.md).
 ```
 
-### Index with digests and package
+### Discovery index
 
 ```json
 {
-  "version": "0.2.0",
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "skills": [
     {
-      "name": "data-pipeline",
-      "description": "Build and validate data pipelines. Use when processing datasets or ETL workflows.",
-      "digest": "sha256:b7e23ec29af22b0b4e41da31e868d57226121c84...",
-      "files": [
-        { "path": "SKILL.md", "digest": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e..." },
-        { "path": "assets/config.template.yaml", "digest": "sha256:e3b0c44298fc1c149afbf4c899..." },
-        { "path": "references/ERROR_CODES.md", "digest": "sha256:5e884898da28047151d0e56f8dc..." },
-        { "path": "references/SCHEMA.md", "digest": "sha256:6ca13d52ca70c883e0f0bb101e4..." },
-        { "path": "scripts/transform.py", "digest": "sha256:3c9909afec25354d551dae21590b..." },
-        { "path": "scripts/validate.py", "digest": "sha256:a591a6d40bf420404a011733cfb7..." }
-      ],
-      "package": {
-        "url": "https://example.com/.well-known/agent-skills/data-pipeline.tar.gz",
-        "digest": "sha256:9f86d081884c7d659a2feaa0c55ad015..."
-      }
+      "name": "code-review",
+      "type": "skill-md",
+      "description": "Review code for bugs, security issues, and best practices.",
+      "url": "/.well-known/agent-skills/code-review/SKILL.md",
+      "digest": "sha256:c4d5e6f7..."
+    },
+    {
+      "name": "git-workflow",
+      "type": "skill-md",
+      "description": "Follow team Git conventions for branching and commits.",
+      "url": "/.well-known/agent-skills/git-workflow/SKILL.md",
+      "digest": "sha256:a7b8c9d0..."
+    },
+    {
+      "name": "wrangler",
+      "type": "archive",
+      "description": "Deploy and manage Cloudflare Workers projects.",
+      "url": "/.well-known/agent-skills/wrangler.tar.gz",
+      "digest": "sha256:f1e2d3c4..."
     }
   ]
 }
@@ -468,12 +397,14 @@ Servers MUST:
 
 - Serve `/.well-known/agent-skills/index.json` with `application/json` content type
 - Serve `SKILL.md` files with `text/markdown` or `text/plain` content type
+- Serve `.tar.gz` archives with `application/gzip` content type and `.zip` archives with `application/zip` content type
 - Support `GET` and `HEAD` methods
 - Return `404 Not Found` for skills or files that do not exist
 
 Servers SHOULD:
 
 - Set appropriate `Cache-Control` headers
+- Include CORS headers (e.g., `Access-Control-Allow-Origin`) if skills are intended for consumption by browser-based clients
 
 Clients MUST:
 
@@ -484,36 +415,34 @@ Clients MUST:
 
 Clients discovering skills from a well-known endpoint MUST:
 
-1. **Fetch `index.json`.** Retrieve `/.well-known/agent-skills/index.json` to enumerate available skills and their files.
+1. **Fetch `index.json`.** Retrieve `/.well-known/agent-skills/index.json` to enumerate available skills.
 
-2. **Check version.** Parse the `version` field. If absent, treat the index as v0.1.0. If the major version is unrecognized, warn the user and abort. Clients MUST ignore unrecognized fields.
+2. **Check schema version.** Match the `$schema` field against known schema URIs. If absent, treat the index as v0.1.0. Clients SHOULD NOT process an index with an unrecognized `$schema` URI and SHOULD warn the user. Clients MUST ignore unrecognized fields.
 
-3. **Use digests for caching.** Compare each skill's `digest` against locally cached values. If the digest matches, the skill is unchanged and the client MAY skip fetching its files. This allows clients to efficiently detect whether any updates are needed without downloading file contents.
+3. **Use digests for caching.** Compare each skill's `digest` against locally cached values. If the digest matches, the skill is unchanged and the client MAY skip re-downloading.
 
-4. **Prefetch and verify skill files.** For skills that need updating, use the `files` array to download all resources. After downloading each file, verify its digest against the per-file `digest` in the index. Cache locally to avoid network requests during task execution.
+4. **Fetch and verify skill artifacts.** For skills that need updating:
+   - For `type: "skill-md"`: Download `SKILL.md` from the skill's `url`. Compute its SHA-256 and verify against `digest`.
+   - For `type: "archive"`: Download the archive from the skill's `url`. Compute its SHA-256 and verify against `digest`. Unpack the archive and validate its structure (see [Archive Safety](#archive-safety)).
+   - For an unrecognized `type`: Skip the skill entry and warn the user.
 
-5. **Validate skill integrity.** After all files for a skill are fetched or unpacked, recompute the skill-level digest from file contents using the [deterministic algorithm](#skill-level-digest) and verify it matches the skill's `digest` field.
+5. **Apply progressive disclosure.** Load only `name` and `description` at discovery time. Load `SKILL.md` when a skill is activated. For archive-based skills, load supporting resources (scripts, references, assets) on demand as the task requires.
 
-6. **Apply progressive disclosure.** Load only `name` and `description` at discovery time. Load `SKILL.md` when a skill is activated. Load supporting resources (scripts, references, assets) on demand as the task requires.
+6. **Cache aggressively.** Skills change infrequently. Respect `Cache-Control` headers and consider caching content for the duration of a session. Use skill digests to invalidate cached content when updates are detected.
 
-7. **Resolve relative paths.** File paths in the `files` array are relative to the skill directory. Resolve against the skill URL:
-   - Skill: `/.well-known/agent-skills/wrangler/`
-   - File entry path: `scripts/deploy.sh`
-   - Resolved URL: `/.well-known/agent-skills/wrangler/scripts/deploy.sh`
-
-8. **Cache aggressively.** Skills change infrequently. Respect `Cache-Control` headers and consider caching content for the duration of a session. Use skill digests to invalidate cached content when updates are detected.
-
-9. **Gate script execution.** Clients SHALL NOT execute files under `scripts/` by default. Clients SHALL consider implementing a permissions model that only executes scripts bundled with a skill when explicitly allowed by the user or client configuration. Consider sandboxing execution environments and restricting filesystem and network access. Never execute scripts from untrusted origins without user approval.
+7. **Gate script execution.** Clients SHALL NOT execute files under `scripts/` by default. Clients SHALL consider implementing a permissions model that only executes scripts bundled with a skill when explicitly allowed by the user or client configuration. Consider sandboxing execution environments and restricting filesystem and network access. Never execute scripts from untrusted origins without user approval.
 
 ## Security Considerations
 
 The security considerations from [RFC 8615 Section 4](https://datatracker.ietf.org/doc/html/rfc8615#section-4) apply. Additional considerations for skills:
 
 - **Trust**: Skills contain instructions and executable code. Agents should only use skills from trusted origins. See the [Agent Skills security guidance](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#security-considerations).
+- **Prompt injection**: Skill content is loaded directly into agent context. A malicious `SKILL.md` can inject instructions that alter agent behavior. Clients SHOULD validate that skill artifacts originate from trusted, allowlisted domains before loading them into context.
+- **Origin allowlisting**: Clients SHOULD maintain a configurable allowlist of trusted domains from which skills may be fetched. Skills from origins not on the allowlist SHOULD be rejected unless the user explicitly approves them.
 - **Access control**: Servers should control write access to `/.well-known/agent-skills/` carefully, especially in shared hosting environments.
 - **Script execution**: Clients SHALL NOT execute files under `scripts/` by default. Clients SHALL consider implementing a permissions model that only executes scripts bundled with a skill when explicitly allowed by the user or client configuration. Refer to the [Agent Skills specification](https://agentskills.io/specification) guidance on script execution.
-- **Digest verification**: Clients MUST verify file digests after download. A digest mismatch indicates the content has been tampered with or is stale; clients MUST NOT use unverified content.
-- **Archive safety**: Clients MUST validate archive digests before unpacking. Clients MUST reject archives containing path traversal sequences (`..`, absolute paths). Clients SHOULD verify total unpacked size against reasonable limits to prevent denial-of-service via decompression bombs.
+- **Digest verification**: Clients MUST verify artifact digests after download. A digest mismatch indicates the content has been tampered with or is stale; clients MUST NOT use unverified content.
+- **Archive safety**: Clients MUST validate archive digests before unpacking. Clients MUST reject archives containing path traversal sequences (`..`, absolute paths) or symlinks and hard links that resolve outside the skill directory. Clients SHOULD verify total unpacked size against reasonable limits to prevent denial-of-service via decompression bombs.
 - **External references**: Skills that fetch external resources introduce additional trust boundaries.
 
 ## Relationship to Existing Specifications
@@ -521,6 +450,7 @@ The security considerations from [RFC 8615 Section 4](https://datatracker.ietf.o
 This document builds on:
 
 - [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) - Key Words for Use in RFCs to Indicate Requirement Levels
+- [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) - Uniform Resource Identifier (URI): Generic Syntax
 - [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174) - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words
 - [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) - Well-Known URIs
 - [Agent Skills Specification](https://agentskills.io/specification) - Skill format and structure
@@ -529,6 +459,7 @@ This document builds on:
 
 - [Agent Skills](https://agentskills.io/) - Open standard for agent skills
 - [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) - Key Words for Use in RFCs to Indicate Requirement Levels
+- [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) - Uniform Resource Identifier (URI): Generic Syntax
 - [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174) - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words
 - [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) - Well-Known Uniform Resource Identifiers
 - [Claude Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)

--- a/examples/skills-index.astro.ts
+++ b/examples/skills-index.astro.ts
@@ -3,8 +3,11 @@
  * Runs at build time (static) or request time (SSR) depending on your Astro config.
  *
  * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
- * from each SKILL.md, collects all files with SHA-256 digests, and outputs a JSON
- * index per the Agent Skills Discovery spec (v0.2.0).
+ * from each SKILL.md, computes SHA-256 digests, and outputs a JSON index per the
+ * Agent Skills Discovery spec (v0.2.0).
+ *
+ * This implementation generates `type: "skill-md"` entries only. Archive-based
+ * skills (`type: "archive"`) require separate tooling to create and register.
  *
  * Usage: Place this file at src/pages/.well-known/agent-skills/index.json.ts
  * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
@@ -13,57 +16,22 @@
  */
 import { createHash } from "crypto";
 import { readdir, readFile } from "fs/promises";
-import { join, relative } from "path";
+import { join } from "path";
 import matter from "gray-matter";
-
-interface FileEntry {
-	path: string;
-	digest: string;
-}
 
 interface Skill {
 	name: string;
+	type: "skill-md";
 	description: string;
+	url: string;
 	digest: string;
-	files: FileEntry[];
 }
+
+const SCHEMA_URI = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
 
 /** SHA-256 digest of a buffer, formatted as sha256:{hex} */
 function sha256(data: Buffer): string {
 	return `sha256:${createHash("sha256").update(data).digest("hex")}`;
-}
-
-/** Compute the skill-level digest from sorted file entries */
-function computeSkillDigest(files: FileEntry[]): string {
-	const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
-	const manifest = sorted
-		.map((f) => `${f.path}\0${f.digest.slice("sha256:".length)}\n`)
-		.join("");
-	return sha256(Buffer.from(manifest, "utf-8"));
-}
-
-/** Recursively collect all files with digests, returning paths relative to baseDir */
-async function collectFiles(
-	dir: string,
-	baseDir: string,
-): Promise<FileEntry[]> {
-	const entries = await readdir(dir, { withFileTypes: true });
-	const files: FileEntry[] = [];
-
-	for (const entry of entries) {
-		const fullPath = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			files.push(...(await collectFiles(fullPath, baseDir)));
-		} else if (entry.isFile()) {
-			const content = await readFile(fullPath);
-			files.push({
-				path: relative(baseDir, fullPath),
-				digest: sha256(content),
-			});
-		}
-	}
-
-	return files;
 }
 
 export async function GET() {
@@ -74,7 +42,7 @@ export async function GET() {
 		entries = await readdir(skillsDir, { withFileTypes: true });
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return Response.json({ version: "0.2.0", skills: [] });
+			return Response.json({ $schema: SCHEMA_URI, skills: [] });
 		}
 		throw error;
 	}
@@ -83,26 +51,19 @@ export async function GET() {
 	const skills: Skill[] = [];
 
 	for (const dir of skillDirs) {
-		const skillDirPath = join(skillsDir, dir.name);
-		const skillPath = join(skillDirPath, "SKILL.md");
+		const skillPath = join(skillsDir, dir.name, "SKILL.md");
 
 		try {
-			const content = await readFile(skillPath, "utf-8");
-			const { data } = matter(content);
+			const content = await readFile(skillPath);
+			const { data } = matter(content.toString("utf-8"));
 
 			if (data.name && data.description) {
-				const allFiles = await collectFiles(skillDirPath, skillDirPath);
-				const skillMd = allFiles.find((f) => f.path === "SKILL.md");
-				const rest = allFiles
-					.filter((f) => f.path !== "SKILL.md")
-					.sort((a, b) => a.path.localeCompare(b.path));
-				const files = skillMd ? [skillMd, ...rest] : rest;
-
 				skills.push({
 					name: data.name,
+					type: "skill-md",
 					description: data.description,
-					digest: computeSkillDigest(files),
-					files,
+					url: `/.well-known/agent-skills/${dir.name}/SKILL.md`,
+					digest: sha256(content),
 				});
 			} else {
 				console.warn(
@@ -118,5 +79,5 @@ export async function GET() {
 
 	skills.sort((a, b) => a.name.localeCompare(b.name));
 
-	return Response.json({ version: "0.2.0", skills });
+	return Response.json({ $schema: SCHEMA_URI, skills });
 }

--- a/examples/skills-index.cgi
+++ b/examples/skills-index.cgi
@@ -4,8 +4,11 @@
 # A throwback to simpler times. Works with Apache, Nginx (via fcgiwrap), or any CGI-capable server.
 #
 # Scans the skills directory for subdirectories, parses YAML frontmatter
-# from each SKILL.md, collects all files with SHA-256 digests, and outputs
-# a JSON index per the Agent Skills Discovery spec (v0.2.0).
+# from each SKILL.md, computes SHA-256 digests, and outputs a JSON index
+# per the Agent Skills Discovery spec (v0.2.0).
+#
+# This implementation generates `type: "skill-md"` entries only. Archive-based
+# skills (`type: "archive"`) require separate tooling to create and register.
 #
 # Usage: Place in cgi-bin/ and configure your server to serve it at /.well-known/agent-skills/index.json
 # Skills: Place skill directories at /var/www/html/.well-known/agent-skills/{name}/SKILL.md
@@ -16,12 +19,12 @@
 #
 use strict;
 use warnings;
-use File::Find;
 use Digest::SHA qw(sha256_hex);
 use JSON::PP;
 
 # Configure this path to match your setup
 my $skills_dir = $ENV{SKILLS_DIR} || '/var/www/html/.well-known/agent-skills';
+my $schema_uri = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 
 print "Content-Type: application/json\r\n";
 print "Cache-Control: public, max-age=300\r\n\r\n";
@@ -40,11 +43,17 @@ if (opendir(my $dh, $skills_dir)) {
 
         # Parse YAML frontmatter
         my ($name, $description);
-        if (open(my $fh, '<', $skill_md)) {
-            my $in_frontmatter = 0;
+        my $content;
+        if (open(my $fh, '<:raw', $skill_md)) {
+            local $/;
+            $content = <$fh>;
+            close($fh);
 
-            while (my $line = <$fh>) {
-                chomp $line;
+            my $text = $content;
+            utf8::decode($text);
+
+            my $in_frontmatter = 0;
+            for my $line (split /\n/, $text) {
                 if ($line eq '---') {
                     if ($in_frontmatter) {
                         last;  # End of frontmatter
@@ -64,7 +73,6 @@ if (opendir(my $dh, $skills_dir)) {
                     }
                 }
             }
-            close($fh);
         }
 
         unless ($name && $description) {
@@ -72,62 +80,27 @@ if (opendir(my $dh, $skills_dir)) {
             next;
         }
 
-        # Collect all files with digests
-        my @files;
-        find({
-            no_chdir => 1,
-            wanted => sub {
-                return unless -f $_;
-                return if -l $_;  # Skip symlinks
-
-                my $rel = $File::Find::name;
-                $rel =~ s/^\Q$skill_path\E\///;
-
-                # Read file and compute SHA-256
-                if (open(my $ffh, '<:raw', $_)) {
-                    local $/;
-                    my $content = <$ffh>;
-                    close($ffh);
-
-                    push @files, {
-                        path   => $rel,
-                        digest => "sha256:" . sha256_hex($content),
-                    };
-                }
-            },
-        }, $skill_path);
-
-        # Sort: SKILL.md first, then alphabetically by path
-        my @sorted = sort {
-            ($a->{path} eq 'SKILL.md') ? -1 :
-            ($b->{path} eq 'SKILL.md') ?  1 :
-            $a->{path} cmp $b->{path}
-        } @files;
-
-        # Compute skill-level digest from sorted file entries
-        my @manifest_sorted = sort { $a->{path} cmp $b->{path} } @files;
-        my $manifest = join('', map {
-            my $hex = $_->{digest};
-            $hex =~ s/^sha256://;
-            "$_->{path}\0$hex\n"
-        } @manifest_sorted);
-        my $skill_digest = "sha256:" . sha256_hex($manifest);
+        # Compute SHA-256 of the SKILL.md file
+        my $digest = "sha256:" . sha256_hex($content);
 
         push @skills, {
             name        => $name,
+            type        => 'skill-md',
             description => $description,
-            digest      => $skill_digest,
-            files       => \@sorted,
+            url         => "/.well-known/agent-skills/$entry/SKILL.md",
+            digest      => $digest,
         };
     }
     closedir($dh);
 } else {
     # Directory doesn't exist - return empty array
-    print encode_json({ version => '0.2.0', skills => [] });
+    print encode_json({ '$schema' => $schema_uri, skills => [] });
     exit 0;
 }
 
 # Sort alphabetically by name
 @skills = sort { $a->{name} cmp $b->{name} } @skills;
 
-print encode_json({ version => '0.2.0', skills => \@skills });
+# Ensure consistent field ordering in JSON output
+my $json = JSON::PP->new->canonical(1);
+print $json->encode({ '$schema' => $schema_uri, skills => \@skills });

--- a/examples/skills-index.nextjs.ts
+++ b/examples/skills-index.nextjs.ts
@@ -3,8 +3,11 @@
  * Runs at build time when using static export, or at request time (cached via route config).
  *
  * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
- * from each SKILL.md, collects all files with SHA-256 digests, and outputs a JSON
- * index per the Agent Skills Discovery spec (v0.2.0).
+ * from each SKILL.md, computes SHA-256 digests, and outputs a JSON index per the
+ * Agent Skills Discovery spec (v0.2.0).
+ *
+ * This implementation generates `type: "skill-md"` entries only. Archive-based
+ * skills (`type: "archive"`) require separate tooling to create and register.
  *
  * Usage: Place this file at app/.well-known/agent-skills/index.json/route.ts
  * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
@@ -13,57 +16,22 @@
  */
 import { createHash } from "crypto";
 import { readdir, readFile } from "fs/promises";
-import { join, relative } from "path";
+import { join } from "path";
 import matter from "gray-matter";
-
-interface FileEntry {
-	path: string;
-	digest: string;
-}
 
 interface Skill {
 	name: string;
+	type: "skill-md";
 	description: string;
+	url: string;
 	digest: string;
-	files: FileEntry[];
 }
+
+const SCHEMA_URI = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
 
 /** SHA-256 digest of a buffer, formatted as sha256:{hex} */
 function sha256(data: Buffer): string {
 	return `sha256:${createHash("sha256").update(data).digest("hex")}`;
-}
-
-/** Compute the skill-level digest from sorted file entries */
-function computeSkillDigest(files: FileEntry[]): string {
-	const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
-	const manifest = sorted
-		.map((f) => `${f.path}\0${f.digest.slice("sha256:".length)}\n`)
-		.join("");
-	return sha256(Buffer.from(manifest, "utf-8"));
-}
-
-/** Recursively collect all files with digests, returning paths relative to baseDir */
-async function collectFiles(
-	dir: string,
-	baseDir: string,
-): Promise<FileEntry[]> {
-	const entries = await readdir(dir, { withFileTypes: true });
-	const files: FileEntry[] = [];
-
-	for (const entry of entries) {
-		const fullPath = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			files.push(...(await collectFiles(fullPath, baseDir)));
-		} else if (entry.isFile()) {
-			const content = await readFile(fullPath);
-			files.push({
-				path: relative(baseDir, fullPath),
-				digest: sha256(content),
-			});
-		}
-	}
-
-	return files;
 }
 
 // Static generation - pre-render at build time
@@ -77,7 +45,7 @@ export async function GET() {
 		entries = await readdir(skillsDir, { withFileTypes: true });
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return Response.json({ version: "0.2.0", skills: [] });
+			return Response.json({ $schema: SCHEMA_URI, skills: [] });
 		}
 		throw error;
 	}
@@ -86,26 +54,19 @@ export async function GET() {
 	const skills: Skill[] = [];
 
 	for (const dir of skillDirs) {
-		const skillDirPath = join(skillsDir, dir.name);
-		const skillPath = join(skillDirPath, "SKILL.md");
+		const skillPath = join(skillsDir, dir.name, "SKILL.md");
 
 		try {
-			const content = await readFile(skillPath, "utf-8");
-			const { data } = matter(content);
+			const content = await readFile(skillPath);
+			const { data } = matter(content.toString("utf-8"));
 
 			if (data.name && data.description) {
-				const allFiles = await collectFiles(skillDirPath, skillDirPath);
-				const skillMd = allFiles.find((f) => f.path === "SKILL.md");
-				const rest = allFiles
-					.filter((f) => f.path !== "SKILL.md")
-					.sort((a, b) => a.path.localeCompare(b.path));
-				const files = skillMd ? [skillMd, ...rest] : rest;
-
 				skills.push({
 					name: data.name,
+					type: "skill-md",
 					description: data.description,
-					digest: computeSkillDigest(files),
-					files,
+					url: `/.well-known/agent-skills/${dir.name}/SKILL.md`,
+					digest: sha256(content),
 				});
 			} else {
 				console.warn(
@@ -121,5 +82,5 @@ export async function GET() {
 
 	skills.sort((a, b) => a.name.localeCompare(b.name));
 
-	return Response.json({ version: "0.2.0", skills });
+	return Response.json({ $schema: SCHEMA_URI, skills });
 }

--- a/examples/skills-index.tanstack.ts
+++ b/examples/skills-index.tanstack.ts
@@ -3,8 +3,11 @@
  * Runs at request time.
  *
  * Scans public/.well-known/agent-skills/ for skill directories, parses YAML frontmatter
- * from each SKILL.md, collects all files with SHA-256 digests, and outputs a JSON
- * index per the Agent Skills Discovery spec (v0.2.0).
+ * from each SKILL.md, computes SHA-256 digests, and outputs a JSON index per the
+ * Agent Skills Discovery spec (v0.2.0).
+ *
+ * This implementation generates `type: "skill-md"` entries only. Archive-based
+ * skills (`type: "archive"`) require separate tooling to create and register.
  *
  * Usage: Place this file at app/routes/.well-known/agent-skills/index.json.ts
  * Skills: Place skill directories at public/.well-known/agent-skills/{name}/SKILL.md
@@ -13,58 +16,23 @@
  */
 import { createHash } from "crypto";
 import { readdir, readFile } from "fs/promises";
-import { join, relative } from "path";
+import { join } from "path";
 import matter from "gray-matter";
 import { createAPIFileRoute } from "@tanstack/react-start/api";
 
-interface FileEntry {
-	path: string;
+interface Skill {
+	name: string;
+	type: "skill-md";
+	description: string;
+	url: string;
 	digest: string;
 }
 
-interface Skill {
-	name: string;
-	description: string;
-	digest: string;
-	files: FileEntry[];
-}
+const SCHEMA_URI = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
 
 /** SHA-256 digest of a buffer, formatted as sha256:{hex} */
 function sha256(data: Buffer): string {
 	return `sha256:${createHash("sha256").update(data).digest("hex")}`;
-}
-
-/** Compute the skill-level digest from sorted file entries */
-function computeSkillDigest(files: FileEntry[]): string {
-	const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
-	const manifest = sorted
-		.map((f) => `${f.path}\0${f.digest.slice("sha256:".length)}\n`)
-		.join("");
-	return sha256(Buffer.from(manifest, "utf-8"));
-}
-
-/** Recursively collect all files with digests, returning paths relative to baseDir */
-async function collectFiles(
-	dir: string,
-	baseDir: string,
-): Promise<FileEntry[]> {
-	const entries = await readdir(dir, { withFileTypes: true });
-	const files: FileEntry[] = [];
-
-	for (const entry of entries) {
-		const fullPath = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			files.push(...(await collectFiles(fullPath, baseDir)));
-		} else if (entry.isFile()) {
-			const content = await readFile(fullPath);
-			files.push({
-				path: relative(baseDir, fullPath),
-				digest: sha256(content),
-			});
-		}
-	}
-
-	return files;
 }
 
 export const APIRoute = createAPIFileRoute("/.well-known/agent-skills/index.json")({
@@ -76,7 +44,7 @@ export const APIRoute = createAPIFileRoute("/.well-known/agent-skills/index.json
 			entries = await readdir(skillsDir, { withFileTypes: true });
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-				return Response.json({ version: "0.2.0", skills: [] });
+				return Response.json({ $schema: SCHEMA_URI, skills: [] });
 			}
 			throw error;
 		}
@@ -85,26 +53,19 @@ export const APIRoute = createAPIFileRoute("/.well-known/agent-skills/index.json
 		const skills: Skill[] = [];
 
 		for (const dir of skillDirs) {
-			const skillDirPath = join(skillsDir, dir.name);
-			const skillPath = join(skillDirPath, "SKILL.md");
+			const skillPath = join(skillsDir, dir.name, "SKILL.md");
 
 			try {
-				const content = await readFile(skillPath, "utf-8");
-				const { data } = matter(content);
+				const content = await readFile(skillPath);
+				const { data } = matter(content.toString("utf-8"));
 
 				if (data.name && data.description) {
-					const allFiles = await collectFiles(skillDirPath, skillDirPath);
-					const skillMd = allFiles.find((f) => f.path === "SKILL.md");
-					const rest = allFiles
-						.filter((f) => f.path !== "SKILL.md")
-						.sort((a, b) => a.path.localeCompare(b.path));
-					const files = skillMd ? [skillMd, ...rest] : rest;
-
 					skills.push({
 						name: data.name,
+						type: "skill-md",
 						description: data.description,
-						digest: computeSkillDigest(files),
-						files,
+						url: `/.well-known/agent-skills/${dir.name}/SKILL.md`,
+						digest: sha256(content),
 					});
 				} else {
 					console.warn(
@@ -120,6 +81,6 @@ export const APIRoute = createAPIFileRoute("/.well-known/agent-skills/index.json
 
 		skills.sort((a, b) => a.name.localeCompare(b.name));
 
-		return Response.json({ version: "0.2.0", skills });
+		return Response.json({ $schema: SCHEMA_URI, skills });
 	},
 });


### PR DESCRIPTION
The changes from PR #8 were merged into the remote `v0.2.0` branch but did not make it into `main`. This re-applies the changes from that PR:

- replace `files` array and `package` object with a single-artifact model: each skill entry now has `type`, `url`, and `digest`
- replace `version` field with `$schema` URI (`https://schemas.agentskills.io/discovery/0.2.0/schema.json`)
- update spec text, examples, and security considerations accordingly

Files restored from orphaned commit 64d5960 (the PR #8 branch tip).